### PR TITLE
added proxy dhcp

### DIFF
--- a/dhcp/install.sh
+++ b/dhcp/install.sh
@@ -12,7 +12,11 @@ INTERNET=$(ip route | grep default | cut -d' ' -f5)
 LOCAL=$(ip route | grep -v default | cut -d' ' -f3 | grep -v $INTERNET | head -1)
 
 # configuration
-echo "dhcp-range=${NETWORK}.50,${NETWORK}.150,12h" >> /etc/dnsmasq.conf 
+cat <<EOT >> /etc/dnsmasq.conf
+enable-tftp
+pxe-service=x86PC, "Install Linux", /ltsp/amd64/pxelinux, $LAN_IP
+dhcp-range=${LAN_IP},proxy  
+EOT
 
 # restarting service	
 service dnsmasq restart


### PR DESCRIPTION
added `proxy dhcp` server to reconfigure dnsmasq on boot. dhcp server now does not offer ip to client
it provide `tftp` services and information to boot from network

closes #37 