### PR TITLE
released vagrant box version 1.0.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,11 +12,11 @@ NETWORK="$(echo $LAN_IP | cut -d'.' -f1-3)"
 # Adding repository and Updating packages
 add-apt-repository ppa:ts.sch.gr --yes
 apt update --yes
-# Setting type of user interface with a boot parameter - https://www.debian.org/releases/jessie/i386/ch05s03.html 
-DEBIAN_FRONTEND=noninteractive apt upgrade --yes
+apt upgrade --yes
 
 # Installing packages
 apt install --yes --install-recommends ltsp-server epoptes
+# Setting type of user interface with a boot parameter - https://www.debian.org/releases/jessie/i386/ch05s03.html
 DEBIAN_FRONTEND=noninteractive apt install --yes --install-recommends ltsp-client
 apt install --yes ltsp-manager 
 

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ apt upgrade --yes
 apt install --yes --install-recommends ltsp-server epoptes
 # Setting type of user interface with a boot parameter - https://www.debian.org/releases/jessie/i386/ch05s03.html
 DEBIAN_FRONTEND=noninteractive apt install --yes --install-recommends ltsp-client
-apt install --yes ltsp-manager 
+apt install --yes python-twisted ltsp-manager 
 
 # Adding vagrant user to group epoptes
 gpasswd -a ${SUDO_USER:-$(logname)} epoptes


### PR DESCRIPTION
- [x] released vagrant box version `1.0.2` at https://app.vagrantup.com/d78ui98/boxes/linuxmint-19-xfce-32bit
- [x] using a better cleanup script to reduce the size of vagrant box.
- [x] fixed small issue with dependencies of `ltsp-manager`

closes #89 