### PR TITLE
updated dhcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,16 @@ For this project, there are two requirements. Also, it is recommended to use the
 1. Set the interface you want to use by changing `LAN_IF` and save it.
 1. Do a `vagrant up` 
 1. You will have ltsp-server setup in normal mode
+1. Do a `./client.sh` to start the virtual client
 
 ## Installation for standalone mode  
 1. Open `settings.sh`
 1. Change the `STANDALONE` variable to `yes`
+1. Set the interface you want to use by changing `LAN_IF` and save it.
 1. Change the `LAN_IP` variable to whichever IP address you want for ltsp server and save it.
 1. Do a `vagrant up` from the terminal
 1. You will have ltsp-server setup in standalone mode.
+1. Do a `./client.sh` to start the virtual client
 
 ## Automated testing
 Virtual ltsp server project supports automated testing. It is meant to be done with a single computer. `test.sh` script is used for that. 

--- a/dhcp/install.sh
+++ b/dhcp/install.sh
@@ -1,6 +1,7 @@
 #/bin/bash -x
 
 source /vagrant/settings.sh
+NETWORK="$(echo $LAN_IP | cut -d'.' -f1-3)"
 
 # installation
 apt --yes update
@@ -12,11 +13,7 @@ INTERNET=$(ip route | grep default | cut -d' ' -f5)
 LOCAL=$(ip route | grep -v default | cut -d' ' -f3 | grep -v $INTERNET | head -1)
 
 # configuration
-cat <<EOT >> /etc/dnsmasq.conf
-enable-tftp
-pxe-service=x86PC, "Install Linux", /ltsp/amd64/pxelinux, $LAN_IP
-dhcp-range=${LAN_IP},proxy  
-EOT
+echo "dhcp-range=${NETWORK}.20,${NETWORK}.250,8h" >> /etc/dnsmasq.conf
 
 # restarting service	
 service dnsmasq restart


### PR DESCRIPTION
the dhcp server present should be a normal dhcp server. Its function should only be to provide dhcp services. 
The booting information to the client with dnsmasq from ltsp server itself. So dhcp server's function should only be to provide ip address and not booting information.